### PR TITLE
Fix malformed RST

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -1,4 +1,4 @@
-W.. title:: Home
+.. title:: Home
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
During a previous commit, an extra character was added to the header of the main index file. This PR fixes that by removing the extra character.