### PR TITLE
Remove data width requirements for high-bandwidth streams

### DIFF
--- a/source/api/liboni/liboni-example.rst
+++ b/source/api/liboni/liboni-example.rst
@@ -255,23 +255,23 @@ Reading Data Frames
 ********************************************
 :struct:`oni_frame_t`'s are minimal packets containing metadata and raw binary
 data blocks from a single device within the device table. A
-:struct:`oni_size_t` is defined as
+:struct:`oni_frame_t` is defined as
 
 .. code-block:: c
 
     struct oni_frame {
-        const uint64_t dev_idx;  // Device index that produced or accepts the frame
-        const uint32_t data_sz;  // Size in bytes of data buffer
-        const uint64_t time;     // Frame time (ACQCLKHZ)
-        uint8_t *data;           // Raw data block
+        const oni_size_t dev_idx;   // Device index that produced or accepts the frame
+        const oni_size_t data_sz;   // Size in bytes of data buffer
+        const oni_counter_t time;   // Frame time (ACQCLKHZ)
+        uint8_t *data;              // Raw data block
     };
 
 where ``dev_idx`` is the fully qualified device index within the device table
-(hub.index), ``data_sz`` is the size in bytes of the raw data block, ``time``
-is the system clock count that indicates the frame creation time, and, ``data``
-is a pointer to the raw data block. A single frame can be read from an
-acquisition context after it is started (see :ref:`start_ctx`) using repeated
-calls to ``oni_read_frame`` as follows:
+(hub.index), ``data_sz`` is the size in bytes of the raw data block as specifed
+in the device table, ``time`` is the system clock count that indicates the frame
+creation time, and, ``data`` is a pointer to the raw data block. A single frame
+can be read from an acquisition context after it is started (see
+:ref:`start_ctx`) using repeated calls to ``oni_read_frame`` as follows:
 
 .. code-block:: c
 
@@ -310,9 +310,9 @@ steps to reading frames.
 
     // Required elements to create frame
     oni_frame_t *frame = NULL;
-    size_t dev_idx = 256;
-    size_t data_sz = 8; // or 16, 24, 32, etc
-    char data[] = {0, 1, 2, 3, 4, 5, 6, 7};
+    const size_t dev_idx = 256;
+    const size_t data_sz = 8; // Multiple of write size presented in device table
+    char data[] = {0, 1, 2, 3, 4, 5, 6, 7}; // Must be data_sz bytes long
 
     // Create a frame
     oni_create_frame(ctx, &frame, dev_idx, data, data_sz);
@@ -324,8 +324,8 @@ steps to reading frames.
     oni_destroy_frame(frame);
 
 First, a frame is created using a call to ``oni_create_frame`` (analogous to
-``oni_read_frame``, except that frame data is provided by the user instead of
-the hardware). In the preceding example, it is assumed that the user has
+``oni_read_frame``, except that frame data is provided by the caller instead of
+the hardware). In the preceding example, it is assumed that the caller has
 queried the device table to ensure that the device with qualified index 256 is
 writable and has a write size of 8 bytes. If the device at ``dev_idx`` does not
 accept writes or ``data``/``data_sz`` are not a multiple of the device write

--- a/source/api/liboni/oni.rst
+++ b/source/api/liboni/oni.rst
@@ -121,24 +121,21 @@ Frame
 ---------------------------------------
 .. struct:: oni_frame_t
 
-    .. member:: const oni_fifo_time_t time
-
-        Frame time (:macro:`ONI_OPT_ACQCLKHZ` host clock counter).
-
-    .. member:: const oni_fifo_dat_t dev_idx
+    .. member:: const oni_size_t dev_idx
 
         Device index that produced or accepts the frame.
 
-    .. member:: const oni_fifo_dat_t data_sz
+    .. member:: const oni_size_t data_sz
 
         Size of data in bytes.
 
+    .. member:: const oni_counter_t time
+
+        Frame time (:macro:`ONI_OPT_ACQCLKHZ` host clock counter).
+
     .. member:: uint8_t *data
 
-        Raw data block. This pointer is a zero-copy "view" into a private,
-        referenced-counted buffer managed by the acquisition context.  The
-        handle to this buffer is hidden by the API using some C ``union``
-        magic.
+        Pointer to a ``data_sz``-byte continuous data block.
 
     An ONI-compliant data frame implementation. :struct:`oni_frame_t`'s are
     produced by calls to :func:`oni_read_frame` and consumed by calls to
@@ -346,7 +343,7 @@ needed during the development of user-facing software.
     :ref:`liboni_example_set_buffers`). :struct:`oni_frame_t`'s created during
     calls to :func:`oni_read_frame` are zero-copy views into this buffer.
 
-    .. attention:: It is the user's responsibility to free the resources allocated by
+    .. attention:: It is the caller's responsibility to free the resources allocated by
         this call by passing the resulting frame pointer to
         :func:`oni_destroy_frame`.
 
@@ -360,7 +357,7 @@ needed during the development of user-facing software.
 
     Create an :struct:`oni_frame_t` for consumption by :func:`oni_write_frame`.
 
-    .. attention:: It is the user's responsibility to free the resources allocated by
+    .. attention:: It is the caller's responsibility to free the resources allocated by
         this call by passing the resulting frame pointer to
         :func:`oni_destroy_frame`
 

--- a/source/api/liboni/onidefs.rst
+++ b/source/api/liboni/onidefs.rst
@@ -10,9 +10,6 @@ Macro and constant definitions common to both :ref:`oni.h` and :ref:`onidriver.h
 Integer Types
 ---------------------------------------
 
-.. warning:: All of these types will be almost certainly be deprecated in
-    future API revisions to handle drivers with different channel bit widths.
-
 .. type:: uint32_t oni_size_t
 
     Data sizes are 32-bit uints.
@@ -33,13 +30,9 @@ Integer Types
 
     Registers have 32-bit values.
 
-.. type:: uint32_t oni_fifo_dat_t
+.. type:: uint64_t oni_counter_t
 
-    FIFOs use 32-bit words.
-
-.. type:: uint64_t oni_fifo_time_t
-
-    FIFO bound timers use 64-bit words.
+    Counters use 64-bit words.
 
 .. _onidef_context_options:
 

--- a/source/hw-spec/controller.rst
+++ b/source/hw-spec/controller.rst
@@ -36,7 +36,7 @@ requires an understanding of the :ref:`oni-api`.
 Read Channel
 ------------
 
--  **Word size** : 32 bits
+-  **Data alignment** : 8 bits
 -  **Channel type** : Stream
 -  **Direction** : Read
 
@@ -85,7 +85,7 @@ Where
 Write Channel
 -------------
 
--  **Word size** : 32 bits
+-  **Data alignment** : 8 bits
 -  **Channel type** : Stream
 -  **Direction** : Write
 
@@ -97,15 +97,14 @@ read, but without the ``Common_Timestamp`` field. It is the responsibility of
 the controller to accept frames at any rate the computer might be sending them.
 Currently, there is no defined mechanism to inform the host of any possible
 dropped frame on the write channel, although this can be included in an
-implementation so long as it does not invalidate any other ONI
-requirements.
+implementation so long as it does not invalidate any other ONI requirements.
 
 .. _sig-chan:
 
 Signal channel
 --------------
 
--  **Word size** : 8 bits
+-  **Data alignment** : 8 bits
 -  **Channel type** : Stream
 -  **Direction** : Read
 
@@ -113,10 +112,10 @@ The *signal* channel provides a way for the controller to inform the host of
 configuration results, which may be provided with a significant delay.
 Additionally, it is the channel over which the controller sends the device table
 to the host following a system reset. Signal data MUST be framed into packets
-using Consistent Overhead Byte Stuffing
-(`COBS <https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing>`__).
-Within this scheme, packets are delimited using 0's and always have the
-following format:
+using Consistent Overhead Byte Stuffing (`COBS
+<https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing>`__). Within
+this scheme, packets are delimited using 0's and always have the following
+format:
 
 ::
 
@@ -173,7 +172,7 @@ transaction. For instance, on a successful register read:
 Configuration Channel
 ---------------------
 
--  **Word size** : 32 bits
+-  **Data alignment** : 32 bits
 -  **Channel type** : Register
 -  **Direction** : Read-Write
 

--- a/source/hw-spec/devices.rst
+++ b/source/hw-spec/devices.rst
@@ -70,10 +70,19 @@ table <dev-table>`. The descriptor must contain the following information:
   implemented as a new :ref:`Device ID <dev-id>`.
 - ``Read_Sample_Size``: The length in bytes of a single :ref:`device sample
   <dev-sample>` produced by the device and sent to the :ref:`read stream
-  <com-channels>`.
+  <com-channels>`. This value must be *at least* as a large as the number of
+  bytes in the Device Sample indicated by the :ref:`dev-datasheet-read-format`.
 - ``Write_Sample_Size``: The length in bytes of a single :ref:`device
   sample <dev-sample>` consumed by the device from the :ref:`write stream
-  <com-channels>`.
+  <com-channels>`. This value must be *at least* as a large as the number of
+  bytes in the Device Sample indicated by the :ref:`dev-datasheet-write-format`.
+
+.. note:: ``Read_Sample_Size`` and ``Write_Sample_Size`` may include trailing padding 
+   bytes that are a result of data alignment requirments imposed by different underlying 
+   hardware and drivers. Different types of ONI-compliant :ref:`controller:`
+   may present different ``Read_Sample_Size`` and ``Write_Sample_Size`` for Devices 
+   with identical :ref:`Device IDs <dev-id>`. The API's functionality must not be 
+   affected by this.
 
 .. _dev-sample:
 
@@ -94,7 +103,7 @@ format:
   from the write stream, this value is reserved.
 - ``Payload``: Device-specific data.
 
-  -  For :ref:`read streams <com-channels>`, this data must be of :ref:`Read Sample
+  -  For :ref:`read streams <com-channels>`, this data must be _at least_ :ref:`Read Sample
      Size <dev-desc>` - 8.
   -  For :ref:`write streams <com-channels>`, this data must be of :ref:`Write Sample
      Size <dev-desc>`. Thus, the whole sample packet fits into the sample
@@ -229,6 +238,7 @@ table, but it MUST contain the following columns:
 Additional columns are permitted so long as their information does not conflict
 with that in the required columns.
 
+.. _dev-datasheet-read-format:
 Read Frame Format
 ~~~~~~~~~~~~~~~~~
 If the device produces frames, a
@@ -236,6 +246,7 @@ If the device produces frames, a
 frame structure is required. Bits can be grouped into words as is convenient. If
 no frames are produced, then a statement of such is required.
 
+.. _dev-datasheet-write-format:
 Write Frame Format
 ~~~~~~~~~~~~~~~~~~
 If the device accepts frames, a

--- a/source/hw-spec/devices.rst
+++ b/source/hw-spec/devices.rst
@@ -77,11 +77,11 @@ table <dev-table>`. The descriptor must contain the following information:
   <com-channels>`. This value must be *at least* as a large as the number of
   bytes in the Device Sample indicated by the :ref:`dev-datasheet-write-format`.
 
-.. note:: ``Read_Sample_Size`` and ``Write_Sample_Size`` may include trailing padding 
-   bytes that are a result of data alignment requirments imposed by different underlying 
-   hardware and drivers. Different types of ONI-compliant :ref:`controller:`
-   may present different ``Read_Sample_Size`` and ``Write_Sample_Size`` for Devices 
-   with identical :ref:`Device IDs <dev-id>`. The API's functionality must not be 
+.. note:: ``Read_Sample_Size`` and ``Write_Sample_Size`` may include trailing padding
+   bytes that are a result of data alignment requirments imposed by different underlying
+   hardware and drivers. Different types of ONI-compliant :ref:`controller`
+   may present different ``Read_Sample_Size`` and ``Write_Sample_Size`` for Devices
+   with identical :ref:`Device IDs <dev-id>`. The API's functionality must not be
    affected by this.
 
 .. _dev-sample:
@@ -103,11 +103,11 @@ format:
   from the write stream, this value is reserved.
 - ``Payload``: Device-specific data.
 
-  -  For :ref:`read streams <com-channels>`, this data must be _at least_ :ref:`Read Sample
-     Size <dev-desc>` - 8.
-  -  For :ref:`write streams <com-channels>`, this data must be of :ref:`Write Sample
-     Size <dev-desc>`. Thus, the whole sample packet fits into the sample
-     size specified in the :ref:`device descriptor <dev-desc>`.
+  - For :ref:`read streams <com-channels>`, this data must be *at least*
+    :ref:`Read Sample Size <dev-desc>` - 8.
+  - For :ref:`write streams <com-channels>`, this data must be of :ref:`Write Sample
+    Size <dev-desc>`. Thus, the whole sample packet fits into the sample
+    size specified in the :ref:`device descriptor <dev-desc>`.
 
 .. _dev-register:
 
@@ -239,6 +239,7 @@ Additional columns are permitted so long as their information does not conflict
 with that in the required columns.
 
 .. _dev-datasheet-read-format:
+
 Read Frame Format
 ~~~~~~~~~~~~~~~~~
 If the device produces frames, a
@@ -247,6 +248,7 @@ frame structure is required. Bits can be grouped into words as is convenient. If
 no frames are produced, then a statement of such is required.
 
 .. _dev-datasheet-write-format:
+
 Write Frame Format
 ~~~~~~~~~~~~~~~~~~
 If the device accepts frames, a


### PR DESCRIPTION
- High bandwidth streams, from the perspective of API and device table entries, now operate on bytes
- The hardware is permitted to use trailing padding to meet internal alignment requirements
- Fixes #3 