### PR TITLE
Update hub 0 heartbeat definition

### DIFF
--- a/source/hw-spec/devices/special.rst
+++ b/source/hw-spec/devices/special.rst
@@ -76,9 +76,12 @@ and its firmware, where that hub is located.
 
 Heartbeat Device
 ------------------
-Local hub 0 must contain a “heartbeat device”. This is a simple device that
+Local hub 0 MUST contain a “heartbeat device”. This is a simple device that
 periodically produces :ref:`samples <dev-sample>` containing only the ``Hub
-Timestamp`` and an empty payload, at a minimum rate of 10 Hz. Its ``ENABLE``
-register must be fixed and always active. This device ensures that API calls
+Timestamp`` and an empty payload, at a fixed rate of 100 Hz. Its ``ENABLE``
+register must be read-only and always active. This device ensures that API calls
 accessing the read stream are guaranteed to be unblocked in the case that no
 other devices in the system are producing data.
+
+Other, identical heartbeat devices but with configurable ``ENABLE`` and data
+rate MAY exist as part of any hub.


### PR DESCRIPTION
- ENABLE must be read-only and active
- Sample rate must be fixed 100Hz

- Fixes #29 