### PR TITLE
Add RFC 2119 text at hardware intro page

### DIFF
--- a/source/hw-spec/index.rst
+++ b/source/hw-spec/index.rst
@@ -24,3 +24,7 @@ ONI Hardware Specification
    controller/index
 
 
+.. note:: The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+  NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
+  "OPTIONAL" in this document are to be interpreted as described in
+  `RFC 2119 <https://datatracker.ietf.org/doc/html/rfc2119>`_. 


### PR DESCRIPTION
This is related to issue #38 however for we to close that issue we need to run a last check to ensure proper usage of the key words along the document.