### PR TITLE
Specify heartbeat as required on all hubs

### DIFF
--- a/source/hw-spec/devices/required.rst
+++ b/source/hw-spec/devices/required.rst
@@ -115,13 +115,14 @@ their :ref:`datasheet<hub-datasheet>`.
 
 Heartbeat Device
 ------------------
-Local hub 0 MUST contain a “heartbeat device”.  It MUST expose the register
+All hubs MUST contain a “heartbeat device” at address 0. It MUST expose the register
 interface and read stream, and it MUST NOT expose a write stream. This is a
 simple device that periodically produces :ref:`samples <dev-sample>` containing
 only the ``hubclk_cnt`` and an empty payload, at a fixed rate of 100 Hz. Its
 ``ENABLE`` register must be read-only and always active. This device ensures
 that API calls accessing the read stream are guaranteed to be unblocked in the
-case that no other devices in the system are producing data.
+case that no other devices in the system are producing data as well as providing
+a constant reference for hub clock synchronization if required.
 
 Other, identical heartbeat devices but with configurable ``ENABLE`` and data
 rate MAY exist as part of any hub.


### PR DESCRIPTION
- Fixes #106 

I am not sure if this should be a MUST or a SHOULD.
In theory, a MUST is the best option, it gives consistency across hubs.

In practice, if we make hardware that supports old ONIX1 hubs (e.g. hs64), we need to either ignore this part of the spec or somehow inject the device.

I also said that the heartbeat must always be address 0. I believe this helps with consistency, but we could remove it and leave the specific address to the implementation. 
@jonnew what do you think?